### PR TITLE
Lowering and raising tiles

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -131,6 +131,10 @@ void MainWindow::setupSignals() {
                      scene, SLOT(deleteTiles()));
     QObject::connect(ui->action_Edit_Tiles, SIGNAL(triggered()),
                      scene, SLOT(editTiles()));
+    QObject::connect(ui->action_Raise_Tiles, SIGNAL(triggered()),
+                     scene, SLOT(raiseTiles()));
+    QObject::connect(ui->action_Lower_Tiles, SIGNAL(triggered()),
+                     scene, SLOT(lowerTiles()));
 
     QObject::connect(scene, SIGNAL(edited()),
                      previewWin, SLOT(refresh()));
@@ -289,6 +293,8 @@ void MainWindow::setEditActions(bool val) {
     ui->action_Copy            ->setEnabled(val);
     ui->action_Paste           ->setEnabled(val);
     ui->action_Delete          ->setEnabled(val);
+    ui->action_Raise_Tiles     ->setEnabled(val);
+    ui->action_Lower_Tiles     ->setEnabled(val);
     ui->action_Close_ROM       ->setEnabled(val);
     ui->action_Open_ROM        ->setEnabled(val);
     ui->action_Save_ROM        ->setEnabled(val);

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -95,6 +95,8 @@
     <addaction name="action_Delete"/>
     <addaction name="separator"/>
     <addaction name="action_Edit_Tiles"/>
+    <addaction name="action_Raise_Tiles"/>
+    <addaction name="action_Lower_Tiles"/>
    </widget>
    <widget class="QMenu" name="menuLevel">
     <property name="title">
@@ -470,6 +472,22 @@
   <action name="action_Save_Level_to_File">
    <property name="text">
     <string>Save Level to File...</string>
+   </property>
+  </action>
+  <action name="action_Raise_Tiles">
+   <property name="text">
+    <string>Raise Tiles</string>
+   </property>
+   <property name="shortcut">
+    <string>=</string>
+   </property>
+  </action>
+  <action name="action_Lower_Tiles">
+   <property name="text">
+    <string>Lower Tiles</string>
+   </property>
+   <property name="shortcut">
+    <string>-</string>
    </property>
   </action>
  </widget>

--- a/src/mapscene.cpp
+++ b/src/mapscene.cpp
@@ -355,7 +355,7 @@ void MapScene::lowerTiles() {
             if(level->tiles[selY + i][selX + j].height > 0) {
                level->tiles[selY + i][selX + j].height -= 1;
                changed = true;
-            } else
+            } else      //if the tile is already at 0 and not blank, delete it
                 if(level->tiles[selY + i][selX + j].geometry) {
                    level->tiles[selY + i][selX + j] = noTile;
                    changed = true;

--- a/src/mapscene.cpp
+++ b/src/mapscene.cpp
@@ -299,6 +299,85 @@ void MapScene::deleteTiles() {
                        .arg(selY + selLength - 1));
 }
 
+//Raise selected tiles up by one
+void MapScene::raiseTiles() {
+    // if there is no selection, don't do anything
+    if (selWidth == 0 || selLength == 0) return;
+
+    MapChange *edit = new MapChange(level, selX, selY, selWidth, selLength);
+    edit->setText("raise");
+
+    bool changed = false;
+
+    // raise tiles (unless already max), and create them in empty spaces
+    for (int i = 0; i < selLength && selY + i < MAX_2D_SIZE; i++) {
+        for (int j = 0; j < selWidth && selX + j < MAX_2D_SIZE; j++) {
+            if(level->tiles[selY + i][selX + j].geometry == 0) {
+               level->tiles[selY + i][selX + j].geometry = 1;
+               level->tiles[selY + i][selX + j].height = 0;
+               changed = true;
+            } else
+                if(level->tiles[selY + i][selX + j].height < MAX_HEIGHT) {
+                   level->tiles[selY + i][selX + j].height += 1;
+                   changed = true;
+                }
+        }
+    }
+
+    //only push to undo stack if something happened (to avoid undo's that do nothing)
+    if(changed) {
+        stack.push(edit);
+        emit edited();
+
+        emit statusMessage(QString("Raised (%1, %2) to (%3, %4)")
+                       .arg(selX).arg(selY)
+                       .arg(selX + selWidth - 1)
+                       .arg(selY + selLength - 1));
+    } else {
+        emit statusMessage(QString("Nothing selected can raise"));
+        delete edit;
+    }
+}
+
+//Lower selected tiles by one, or remove if already 0 (lowered to nothing)
+void MapScene::lowerTiles() {
+    // if there is no selection, don't do anything
+    if (selWidth == 0 || selLength == 0) return;
+
+    MapChange *edit = new MapChange(level, selX, selY, selWidth, selLength);
+    edit->setText("lower");
+
+    bool changed = false;
+
+    // lower or remove tiles
+    for (int i = 0; i < selLength && selY + i < MAX_2D_SIZE; i++) {
+        for (int j = 0; j < selWidth && selX + j < MAX_2D_SIZE; j++) {
+            if(level->tiles[selY + i][selX + j].height > 0) {
+               level->tiles[selY + i][selX + j].height -= 1;
+               changed = true;
+            } else
+                if(level->tiles[selY + i][selX + j].geometry) {
+                   level->tiles[selY + i][selX + j] = noTile;
+                   changed = true;
+            }
+        }
+    }
+
+    //only push to undo stack if something happened (to avoid undo's that do nothing)
+    if(changed) {
+        stack.push(edit);
+        emit edited();
+
+        emit statusMessage(QString("Lowered (%1, %2) to (%3, %4)")
+                       .arg(selX).arg(selY)
+                       .arg(selX + selWidth - 1)
+                       .arg(selY + selLength - 1));
+    } else {
+        emit statusMessage(QString("Nothing to lower"));
+        delete edit;
+    }
+}
+
 /*
   Start a new selection on the map scene.
   Called when the mouse is clicked outside of any current selection.

--- a/src/mapscene.h
+++ b/src/mapscene.h
@@ -64,6 +64,8 @@ public slots:
     void copy();
     void paste();
     void deleteTiles();
+    void raiseTiles();
+    void lowerTiles();
     void refresh();
 
 signals:


### PR DESCRIPTION
Said it best in IRC:

[12:23:40] <Aeroxia> can hit + or - to raise or lower the selected tiles, rather than go through a bunch of clicking each time, also creates a flat tile if none was there (like you're raising it from nothing to 1)
[12:25:05] <Aeroxia> it's a bit late for it but it's good practice for me since I haven't done much outside of practice exercises and I wanted this for a level I was doing (it was tedious without)
[12:26:18] <Aeroxia> I've never done a pull request before either and nobody else has for the editor, so I wasn't sure if it would be welcome, but it would be good for me to get used to too
